### PR TITLE
Minor adjustments for x86_64 Linux GCC 12.0.1 and or1k-elf GCC 5.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 # ignore some backup files
 *bak
 
-
+# output
 fpga/de1/db/
 fpga/de1/incremental_db/
 fpga/de1/out/

--- a/fw/ctrl/Makefile
+++ b/fw/ctrl/Makefile
@@ -29,17 +29,11 @@ RANLIB  = $(CROSS_COMPILE)ranlib
 
 
 # flags
-CFLAGS +=   -W -Winline -std=gnu99 -g \
-            -Os \
-            -fomit-frame-pointer -ffreestanding -static -flto -fwhole-program \
-            -fno-strict-aliasing \
-            -fno-builtin -nostdlib \
-            -Wl,--relax \
-            -msoft-mul -msoft-div
-# -fpack_struct
-# -Wpacked -Wpadded
-
-LDFLAGS +=
+CFLAGS  =   -Winline -std=gnu99 -g -Os -fcommon -fomit-frame-pointer  \
+            -ffreestanding -static -flto -fno-strict-aliasing         \
+            -U_FORTIFY_SOURCE -fno-stack-protector -fno-builtin       \
+            -nostdlib -Wl,--relax -msoft-mul -msoft-div
+LDFLAGS  =
 
 
 ### variables ###
@@ -48,9 +42,9 @@ BUILD_T=$$(date +%Y-%m-%d)
 BUILD_TIME=\"$(BUILD_T)\"
 BUILD_N=$$(cat build_num.txt)
 BUILD_NUM=\"$(BUILD_N)\"
-BUILD_R=$$(git rev-parse --verify HEAD)
+BUILD_R=$$(git rev-parse --verify HEAD 2>/dev/null || printf '%s\n' "norev")
 BUILD_REV=\"$(BUILD_R)\"
-BUILD_TG=$$(git describe --tags --abbrev=0)
+BUILD_TG=$$(git describe --tags --abbrev=0 2>/dev/null || printf '%s\n' "notag")
 BUILD_TAG=\"$(BUILD_TG)\"
 
 BINDIR=bin

--- a/fw/ctrl/serial.c
+++ b/fw/ctrl/serial.c
@@ -123,7 +123,7 @@ char *next_word(const char *c)
   while ((*c!=0) && (*c!=' ')) c++;
   while (*c==' ') c++;
   if (*c==0) return NULL;
-  else return c;
+  else return (char *)c;
 }
 
 // txbuf_emit()

--- a/fw/ctrl_boot/Makefile
+++ b/fw/ctrl_boot/Makefile
@@ -38,15 +38,11 @@ HEX2MIF = $(HEX2MIF_DIR)hex2mif.py
 
 
 ### flags ###
-CFLAGS +=   -W -Wall -Wpadded -Winline -std=gnu99 -g \
-            -Os \
-            -fomit-frame-pointer -ffreestanding -static -flto -fwhole-program \
-            -fno-strict-aliasing \
-            -fno-builtin -nostdlib \
-            -Wl,--relax \
-            -msoft-mul -msoft-div
-
-LDFLAGS +=
+CFLAGS  =   -Wall -Wpadded -Winline -std=gnu99 -g -Os                   \
+            -fcommon -fomit-frame-pointer -ffreestanding -static -flto  \
+            -fno-strict-aliasing -U_FORTIFY_SOURCE -fno-stack-protector \
+            -fno-builtin -nostdlib -Wl,--relax -msoft-mul -msoft-div
+LDFLAGS =
 
 XXDFLAGS=-ps -c 4
 HEXFLAGS=-w 8 -s 1024 -n


### PR DESCRIPTION
* Minor adjustments for x86_64 Linux GCC 12.0.1 and or1k-elf GCC 5.2.0

* Tested with:
  * Native: GCC 12.0.1 20220401 (Red Hat 12.0.1-0)
  * OR1K: GCC 5.2.0, binutils 2.26, Newlib 2.3.0 (+or1k backports)